### PR TITLE
Use explicit language setting for lldb

### DIFF
--- a/Classes/XprobePluginMenuController.m
+++ b/Classes/XprobePluginMenuController.m
@@ -142,7 +142,7 @@ static __weak id lastKeyWindow;
         [self performSelector:@selector(loadBundle:) withObject:bundlePath afterDelay:.1];
     else
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND,0), ^{
-            NSString *loader = [NSString stringWithFormat:@"p (void)[[NSBundle bundleWithPath:"
+            NSString *loader = [NSString stringWithFormat:@"expr -l objc++ -- (void)[[NSBundle bundleWithPath:"
                                 "@\"%@\"] load]\r", bundlePath];
             [session executeConsoleCommand:loader threadID:1 stackFrameID:0];
             dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
When debugging a Swift project lldb will inherit the target's language, causing syntax errors when evaluating Objective-C expressions. Fix by making the language explicit via the -l option.